### PR TITLE
#18 - relocated the calls to the generate_xmltv function when parsing the arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ optional arguments:
   -u                  Update the channel list JSON file. Calling with -u will
                       not load XMLTV data!
   -c basic, plus      Change channels to A1TV basic or A1TV plus. Default is
-                      A1TV plus. Loads new EPG data. Change is stored in JSON
-                      file and persistent.
+                      A1TV plus. Change is stored in JSON file and persistent.
+                      Will not load new XMLTV data 
 ```
 
 #### 4.1 Eaxmple for using UNIX socket import on TVHeadend:

--- a/a1tv_epg.py
+++ b/a1tv_epg.py
@@ -36,19 +36,23 @@ if __name__ == "__main__":
                 write_stations(arguments.c)
             else:
                 raise ValueError('Wrong entry for Playlist type!')
-
-        # Load stations and generate XMLTV Data or update station list
-        stations = load_stations()
-        data = generate_xmltv(stations,arguments.t)
-        if arguments.u:
+        elif arguments.u:
             write_stations()
         elif arguments.d == True:
+            stations = load_stations()
+            data = generate_xmltv(stations,arguments.t)
             send_to_tvheadend(data)
         elif arguments.o != None:
+            stations = load_stations()
+            data = generate_xmltv(stations,arguments.t)
             save_to_file(data, arguments.o.name)
         elif arguments.s != None:
+            stations = load_stations()
+            data = generate_xmltv(stations,arguments.t)
             send_to_tvheadend(data, arguments.s)
         else:
+            stations = load_stations()
+            data = generate_xmltv(stations,arguments.t)
             save_to_file(data, 'xmltv.xml')
 
     except IOError as msg:


### PR DESCRIPTION
Reduces unnecessary requests from the API when getting station details is completely unnecessary